### PR TITLE
Make CUDA implementation C++11 compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
     - main
+    - dev
 
   pull_request:
     branches:
     - main
+    - dev
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This is a collection of different C++ implementations for calculating the discre
 Implementations of all these variants can be found under `ffrechet-{vanilla,linear,simd,cuda}/source/` or by simply clicking on the listed names above.
 
 ## Installation
+```bash
+# configure
+$ git submodule --init
+$ cp CMakeUserPresets.json.EXAMPLE CMakeUserPresets.json
+```
 
 ```bash
 # release build & run benchmark

--- a/ffrechet-cuda/CMakeLists.txt
+++ b/ffrechet-cuda/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(
     "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/export>"
 )
 
-target_compile_features(ffrechet-cuda_ffrechet-cuda PUBLIC cxx_std_17)
+target_compile_features(ffrechet-cuda_ffrechet-cuda PUBLIC cxx_std_11)
 
 # ---- Install rules ----
 

--- a/ffrechet-cuda/ffrechet-cuda_toolchain.cmake
+++ b/ffrechet-cuda/ffrechet-cuda_toolchain.cmake
@@ -2,7 +2,7 @@ set(CMAKE_CUDA_HOST_COMPILER g++-10)
 set(CMAKE_CUDA_ARCHITECTURES 75)
 
 set(CMAKE_CXX_COMPILER g++-10)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Werror -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast -march=native -ffast-math")

--- a/ffrechet-cuda/include/ffrechet-cuda/common.hpp
+++ b/ffrechet-cuda/include/ffrechet-cuda/common.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-namespace fast_frechet::cuda
+namespace fast_frechet
+{
+namespace cuda
 {
 void cuda_check();
 void cuda_check(cudaError_t);
-} // namespace fast_frechet::cuda
+} // namespace cuda
+} // namespace fast_frechet

--- a/ffrechet-cuda/include/ffrechet-cuda/ffrechet-cuda.hpp
+++ b/ffrechet-cuda/include/ffrechet-cuda/ffrechet-cuda.hpp
@@ -2,14 +2,17 @@
 
 #include "ffrechet-cuda/ffrechet-cuda_export.hpp"
 
-namespace fast_frechet::cuda
+namespace fast_frechet
+{
+namespace cuda
 {
 struct FFRECHET_CUDA_EXPORT KernelConfig
 {
     unsigned grid_size;
     unsigned block_size;
 };
-} // namespace fast_frechet::cuda
+} // namespace cuda
+} // namespace fast_frechet
 
 extern "C"
 {

--- a/ffrechet-cuda/source/common.cu
+++ b/ffrechet-cuda/source/common.cu
@@ -3,7 +3,9 @@
 
 #include "ffrechet-cuda/ffrechet-cuda.hpp"
 
-namespace fast_frechet::cuda
+namespace fast_frechet
+{
+namespace cuda
 {
 void cuda_check(cudaError_t code)
 {
@@ -17,4 +19,5 @@ void cuda_check()
 {
     cuda_check(cudaGetLastError());
 }
-} // namespace fast_frechet::cuda
+} // namespace cuda
+} // namespace fast_frechet


### PR DESCRIPTION
By splitting the definition of nested namespaces the CUDA implementation becomes compatible with C++11. Besides this, the current implementation does not use any C++>11 features. Therefore, this change allows testing the code on machines with older NVCC versions.